### PR TITLE
Required perl module for LDAP on RT 5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     libmoosex-role-parameterized-perl \
     libnet-cidr-perl \
     libnet-ip-perl \
+    libnet-ldap-perl \
     libplack-perl \
     libregexp-common-net-cidr-perl \
     libregexp-common-perl \


### PR DESCRIPTION
I think this module should be installed by default. RT 5.0 has built in support for LDAP through the Web UI